### PR TITLE
Add label as optional aesthetic for stat_qq_point and stat_pp_point

### DIFF
--- a/R/stat_pp_point.R
+++ b/R/stat_pp_point.R
@@ -126,6 +126,8 @@ StatPpPoint <- ggplot2::ggproto(
 
 	required_aes = c("sample"),
 
+	optional_aes = c("label"),
+
 	compute_group = function(data,
 													 self,
 													 scales,
@@ -135,7 +137,8 @@ StatPpPoint <- ggplot2::ggproto(
 		# cumulative distributional function
 		pFunc <- eval(parse(text = paste0("p", distribution)))
 
-		smp <- sort(data$sample)
+		oidx <- order(data$sample)
+		smp <- data$sample[oidx]
 		n <- length(smp)
 		probs <- ppoints(n)
 
@@ -200,6 +203,7 @@ StatPpPoint <- ggplot2::ggproto(
 			out <- data.frame(sample = y, theoretical = probs)
 		}
 
+		if (!is.null(data$label)) out$label <- data$label[oidx]
 		out
 	}
 )

--- a/R/stat_qq_point.R
+++ b/R/stat_qq_point.R
@@ -156,6 +156,8 @@ StatQqPoint <- ggplot2::ggproto(
 
 	required_aes = c("sample"),
 
+	optional_aes = c("label"),
+
 	compute_group = function(data,
 													 self,
 													 scales,
@@ -248,6 +250,7 @@ StatQqPoint <- ggplot2::ggproto(
 			out <- data.frame(sample = smp, theoretical = theoretical)
 		}
 
+		if (!is.null(data$label)) out$label <- data$label[oidx]
 		out
 	}
 )


### PR DESCRIPTION
This permits usage of these functions with `geom_text()` and related geoms using `aes()` syntax.

Closes https://github.com/aloy/qqplotr/issues/7