### PR TITLE
Compatibility ggplot2 4.0.0

### DIFF
--- a/R/geom_qq_band.R
+++ b/R/geom_qq_band.R
@@ -128,7 +128,9 @@ GeomQqBand <- ggplot2::ggproto(
 		data
 	},
 
-	draw_group = ggplot2::GeomRibbon$draw_group,
+	draw_group = function(...) {
+		ggplot2::GeomRibbon$draw_group(...)
+	},
 
 	draw_key = ggplot2::draw_key_polygon
 )


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
We did not find a problem in qqplotr itself, but shared reverse dependencies implied there should be.

After a bit of head scratching, I finally found the culprit. The issue is that during package build time (e.g. on CRAN's machines), some of your ggproto classes capture (and fix) methods from ggplot2's ggproto classes. That means that if somebody updates ggplot2, they'd still be running the old methods in qqplotr, which can give version mismatches. Such version mismatches appeared in shared reverse dependencies.

The fix isn't too hard, we just need to make sure we call the method rather than to copy the method. This PR does that for the single method that was giving troubles.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun